### PR TITLE
compatibility patch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,13 @@
 /* eslint-disable no-new-func, camelcase */
 /* globals __non_webpack__require__ */
 
-const realImport = new Function('modulePath', 'return import(modulePath)')
+const realImport = typeof process === "undefined" ? new Function('modulePath', 'return import(modulePath)') : async () => {
+  if(modulePath.startsWith('file://')){
+    return realRequire(modulePath.replace(modulePath[9] === ":" ? 'file:///' : 'file://', ''))
+  }else{
+    return realRequire(modulePath)
+  }
+}
 
 function realRequire(modulePath) {
   if (typeof __non_webpack__require__ === 'function') {


### PR DESCRIPTION
This will fix some compatibility issues with some node.js use-cases. This fix will handover the module loading request in node.js to 'require' without breaking the original code in some apps/scripts is that already using this package.

resolves #14 