### PR TITLE
chore!: drop support for node 12 and 17; add support for node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [14, 16, 18]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
BREAKING CHANGE: Drops support for EOL node 12 and 17; adds support for node 18